### PR TITLE
Disabled no_shipping, added buyer address and email

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -141,7 +141,7 @@
 
                 var onAuthorize = function onAuthorize(data, actions) {
                     return actions.payment.execute().then(function (payment_data) {
-                        console.log('payment_data: ' + JSON.stringify(payment_data, null, 1));
+                        // console.log(`payment_data: ${JSON.stringify(payment_data, null, 1)}`)
                         var payment = Object.assign({}, _this2.props.payment);
                         payment.paid = true;
                         payment.cancelled = false;

--- a/dist/index.js
+++ b/dist/index.js
@@ -133,13 +133,15 @@
                         transactions: [{ amount: { total: _this2.props.total, currency: _this2.props.currency } }]
                     }, {
                         input_fields: {
+                            // any values other than null, and the address is not returned after payment execution.
                             no_shipping: _this2.props.shipping
                         }
                     });
                 };
 
                 var onAuthorize = function onAuthorize(data, actions) {
-                    return actions.payment.execute().then(function () {
+                    return actions.payment.execute().then(function (payment_data) {
+                        console.log('payment_data: ' + JSON.stringify(payment_data, null, 1));
                         var payment = Object.assign({}, _this2.props.payment);
                         payment.paid = true;
                         payment.cancelled = false;
@@ -147,6 +149,9 @@
                         payment.paymentID = data.paymentID;
                         payment.paymentToken = data.paymentToken;
                         payment.returnUrl = data.returnUrl;
+                        // getting buyer's shipping address and email
+                        payment.address = payment_data.payer.payer_info.shipping_address;
+                        payment.email = payment_data.payer.payer_info.email;
                         _this2.props.onSuccess(payment);
                     });
                 };
@@ -159,9 +164,11 @@
                         style: this.props.style,
                         payment: payment,
                         commit: true,
-                        shipping: this.props.shipping,
                         onAuthorize: onAuthorize,
                         onCancel: this.props.onCancel
+
+                        // "Error: Unrecognized prop: shipping" was caused by the next line
+                        // shipping={this.props.shipping}
                     });
                 }
                 return _react2.default.createElement(
@@ -184,7 +191,8 @@
 
     PaypalButton.defaultProps = {
         env: 'sandbox',
-        shipping: 0,
+        // null means buyer address is returned in the payment execution response
+        shipping: null,
         onSuccess: function onSuccess(payment) {
             console.log('The payment was succeeded!', payment);
         },

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class PaypalButton extends React.Component {
 
         const onAuthorize = (data, actions) => {
             return actions.payment.execute().then((payment_data) => {
-                console.log(`payment_data: ${JSON.stringify(payment_data, null, 1)}`)
+                // console.log(`payment_data: ${JSON.stringify(payment_data, null, 1)}`)
                 const payment = Object.assign({}, this.props.payment);
                 payment.paid = true;
                 payment.cancelled = false;

--- a/src/index.js
+++ b/src/index.js
@@ -41,13 +41,15 @@ class PaypalButton extends React.Component {
                 ]
             }, {
                 input_fields: {
+                    // any values other than null, and the address is not returned after payment execution.
                     no_shipping: this.props.shipping
                 }
             });
         }
 
         const onAuthorize = (data, actions) => {
-            return actions.payment.execute().then(() => {
+            return actions.payment.execute().then((payment_data) => {
+                console.log(`payment_data: ${JSON.stringify(payment_data, null, 1)}`)
                 const payment = Object.assign({}, this.props.payment);
                 payment.paid = true;
                 payment.cancelled = false;
@@ -55,6 +57,9 @@ class PaypalButton extends React.Component {
                 payment.paymentID = data.paymentID;
                 payment.paymentToken = data.paymentToken;
                 payment.returnUrl = data.returnUrl;
+                // getting buyer's shipping address and email
+                payment.address = payment_data.payer.payer_info.shipping_address;
+                payment.email = payment_data.payer.payer_info.email;
                 this.props.onSuccess(payment);
             })
         }
@@ -67,9 +72,11 @@ class PaypalButton extends React.Component {
                 style={this.props.style}
                 payment={payment}
                 commit={true}
-                shipping={this.props.shipping}
                 onAuthorize={onAuthorize}
                 onCancel={this.props.onCancel}
+
+                // "Error: Unrecognized prop: shipping" was caused by the next line
+                // shipping={this.props.shipping}
             />
         }
         return <div>{ppbtn}</div>;
@@ -85,7 +92,8 @@ PaypalButton.propTypes = {
 
 PaypalButton.defaultProps = {
     env: 'sandbox',
-    shipping: 0,
+    // null means buyer address is returned in the payment execution response
+    shipping: null,
     onSuccess: (payment) => {
         console.log('The payment was succeeded!', payment);
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,14 +1083,6 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-react-class@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1547,7 +1539,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2777,7 +2769,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -2833,24 +2825,23 @@ react-async-script-loader@^0.3.0:
   dependencies:
     hoist-non-react-statics "^1.0.3"
 
-react-dom@^15.5.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+react-dom@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^15.5.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+react@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"


### PR DESCRIPTION
Possible solution for #11, #12, #14, #18.  Basically, disable the recent addition of no_shipping and the shipping prop. Paypal's checkout.js does not seem to have a shipping prop, and I think that's where the error is coming from.

I needed to have the buyer's address to ship the goods, and the email to send the receipt. I added those by reading paypal's execute response. Let me know if I you want me to do something differently, right now these are returned by default.