### PR TITLE
allowing for adding additional info on the payment object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,11 @@ class PaypalButton extends React.Component {
 
     render() {
         let payment = () => {
-            return paypal.rest.payment.create(this.props.env, this.props.client, {
+            return paypal.rest.payment.create(this.props.env, this.props.client, Object.assign({
                 transactions: [
                     { amount: { total: this.props.total, currency: this.props.currency } }
                 ]
-            }, {
+            }, this.props.paymentOptions), {
                 input_fields: {
                     // any values other than null, and the address is not returned after payment execution.
                     no_shipping: this.props.shipping
@@ -91,6 +91,7 @@ PaypalButton.propTypes = {
 }
 
 PaypalButton.defaultProps = {
+    paymentOptions: {},
     env: 'sandbox',
     // null means buyer address is returned in the payment execution response
     shipping: null,


### PR DESCRIPTION
There are other (optional) attributes that can be included on the `payment` payload to paypal.  Notably (for me) `intent:"authorize"`:
https://developer.paypal.com/docs/integration/direct/payments/authorize-and-capture-payments/#authorize-the-payment

There are others that might be useful too, `description`, `invoice_number `, etc.

This allows me render by button like:
>      <PaypalExpressBtn
>          env={this.env}
>          paymentOptions={{intent:'authorize'}} <--- interesting part
>          client={client}
>          currency={currency}
>          total={this.amount}
>          onError={onError}
>          onSuccess={onSuccess}
>          onCancel={onCancel}
>        />

Thanks!
