### PR TITLE
SSR compatibility patch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -86,9 +86,12 @@
             _classCallCheck(this, PaypalButton);
 
             var _this = _possibleConstructorReturn(this, (PaypalButton.__proto__ || Object.getPrototypeOf(PaypalButton)).call(this, props));
+            
+            if (typeof window !== `undefined`) {
+                window.React = _react2.default;
+                window.ReactDOM = _reactDom2.default;
+            }
 
-            window.React = _react2.default;
-            window.ReactDOM = _reactDom2.default;
             _this.state = {
                 showButton: false
             };

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,10 @@ import PropTypes from 'prop-types';
 class PaypalButton extends React.Component {
     constructor(props) {
         super(props);
-        window.React = React;
-        window.ReactDOM = ReactDOM;
+        if (typeof window !== `undefined`) {
+            window.React = React;
+            window.ReactDOM = ReactDOM;
+        }
         this.state = {
             showButton: false
         }


### PR DESCRIPTION
Working with Gatsby the window property assignment works fine in development build but fails in deployment builds because 'window' is not available.  Simple conditional assignment I am presuming preferable to componentDidMount style solutions as unintended side effects are minimized.

Thanks for this fantastic repo!  works great(almost!) with Gatsby where all other paypal solutions seem to fail