### PR TITLE
Allowing for adding additional info on the transaction object

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ export default class MyApp extends React.Component {
 - `client: Object (with "sandbox" and "production" as keys)` - MUST set, please see the above example
 - `currency: String ("USD", "JPY" etc.)` - MUST set, please see the above example
 - `total: Number (1.00 or 1 - depends on currency)` - MUST set, please see the above example
+- `transactionOptions: Object` - MUST be a valid [purchase object](https://developer.paypal.com/docs/api/orders/v2/#definition-purchase_unit_request)
 - `shipping: Number (1 or 2 or 3)` - Ability to change if a shipping address is included in checkout, 0 is default and means optional, 1 is no shipping address, 2 is shipping is required
 - `onError: Callback function (happens when Paypal's main script cannot be loaded)` - If not set, this will take the above function (in example) as a default return
 - `onSuccess: Callback function (happens after payment has been finished successfully)` - If not set, this will take the above function (in example) as a default return

--- a/dist/index.js
+++ b/dist/index.js
@@ -130,7 +130,7 @@
 
                 var payment = function payment() {
                     return paypal.rest.payment.create(_this2.props.env, _this2.props.client, Object.assign({
-                        transactions: [{ amount: { total: _this2.props.total, currency: _this2.props.currency } }]
+                        transactions: [Object.assign(_this2.props.transactionOptions, { amount: { total: _this2.props.total, currency: _this2.props.currency } })]
                     }, _this2.props.paymentOptions), {
                         input_fields: {
                             // any values other than null, and the address is not returned after payment execution.
@@ -185,6 +185,7 @@
     PaypalButton.propTypes = {
         currency: _propTypes2.default.string.isRequired,
         total: _propTypes2.default.number.isRequired,
+        transactionOptions: _propTypes2.default.object,
         client: _propTypes2.default.object.isRequired,
         style: _propTypes2.default.object
     };
@@ -192,6 +193,7 @@
     PaypalButton.defaultProps = {
         paymentOptions: {},
         env: 'sandbox',
+        transactionOptions: {},
         // null means buyer address is returned in the payment execution response
         shipping: null,
         onSuccess: function onSuccess(payment) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,10 @@ class PaypalButton extends React.Component {
         let payment = () => {
             return paypal.rest.payment.create(this.props.env, this.props.client, Object.assign({
                 transactions: [
-                    { amount: { total: this.props.total, currency: this.props.currency } }
+                    Object.assign(
+                        this.props.transactionOptions,
+                        { amount: { total: this.props.total, currency: this.props.currency } }
+                    )
                 ]
             }, this.props.paymentOptions), {
                 input_fields: {
@@ -86,6 +89,7 @@ class PaypalButton extends React.Component {
 PaypalButton.propTypes = {
     currency: PropTypes.string.isRequired,
     total: PropTypes.number.isRequired,
+    transactionOptions: PropTypes.object,
     client: PropTypes.object.isRequired,
     style: PropTypes.object
 }
@@ -93,6 +97,7 @@ PaypalButton.propTypes = {
 PaypalButton.defaultProps = {
     paymentOptions: {},
     env: 'sandbox',
+    transactionOptions: {},
     // null means buyer address is returned in the payment execution response
     shipping: null,
     onSuccess: (payment) => {


### PR DESCRIPTION
Will be useful with integration of PayPal IPN to match params on
frontend and backend

Any thoughts on better implementation?

And yeah, it's different from b885cfde3b81e1b33e1f479a7cc77326934be090, this fix is allowing to pass custom field, that will be returned with payment object on backend